### PR TITLE
Avoid infinite loop when config is missing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ modules.
 
 ::
 
-    pip install flake8-import-graph==0.1.3
+    pip install flake8-import-graph==0.1.4
 
 
 Configure it, by putting ``.flake8`` file in the package root:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.rst'), 'rt') as f:
     long_description = f.read()
 
 setup(name='flake8-import-graph',
-      version='0.1.3',
+      version='0.1.4',
       description="A flake8 lint to enforce that some modules "
                   "can't be imported from other modules.",
       author='Paul Colomiets',

--- a/src/flake8_import_graph/__init__.py
+++ b/src/flake8_import_graph/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 
 from .checker import ImportGraphChecker

--- a/src/flake8_import_graph/checker.py
+++ b/src/flake8_import_graph/checker.py
@@ -64,6 +64,9 @@ class ImportGraphChecker:
         while path:
             if os.path.exists(os.path.join(path, '.flake8')):
                 break
+            if path == '/':
+                self.module = None
+                return
             dir, name = os.path.split(path)
             mod_path.insert(0, name)
             path = dir
@@ -77,6 +80,8 @@ class ImportGraphChecker:
             cls.denied_imports.append((src.split('.'), dest.split('.')))
 
     def run(self):
+        if self.module is None:
+            return None
         errors = []
         visitor = ImportVisitor(self.module, errors, self.denied_imports)
         visitor.visit(self.tree)


### PR DESCRIPTION
Resolve https://github.com/tailhook/flake8-import-graph/issues/1

When config is not present in the path checker hangs.
For example this could happen when filename is `/dev/null`

(For some reason flake8 instantiate checker with such value)