### PR TITLE
Add option to exempt subpackages from denied imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,9 @@ Configure it, by putting ``.flake8`` file in the package root:
         myapp.models=myapp.controllers
         # Don't allow controllers to import sqlalchemy directly
         myapp.controllers=sqlalchemy
+        # In spite of the above, allow myapp.models.special to import anything
+        except+=myapp.models.special
+        # (many "except+=" entries are allowed)
 
 
 License


### PR DESCRIPTION
The option is activated by adding `except+=...` entries to the denied_imports list. The named modules are then allowed to import anything.

