### PR TITLE
Add option to exempt subpackages from denied imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,10 @@ Configure it, by putting ``.flake8`` file in the package root:
         myapp.models=myapp.controllers
         # Don't allow controllers to import sqlalchemy directly
         myapp.controllers=sqlalchemy
+    allow-all-imports =
+        # In spite of the above, allow myapp.models.special to import anything
+        myapp.models.special
+        # (many entries are allowed)
 
 
 License

--- a/examples/e02/.flake8
+++ b/examples/e02/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+deny-imports =
+    file1=pkg
+    pkg=file1
+allow-all-imports =
+    pkg.special

--- a/examples/e02/central.py
+++ b/examples/e02/central.py
@@ -1,0 +1,5 @@
+import file1
+from pkg import normal, special
+
+
+__all__ = ['file1', 'normal', 'special']

--- a/examples/e02/file1.py
+++ b/examples/e02/file1.py
@@ -1,0 +1,5 @@
+import pkg.normal  # disallowed
+from pkg import special  # disallowed
+
+
+__all__ = ['pkg', 'special']

--- a/examples/e02/pkg/normal.py
+++ b/examples/e02/pkg/normal.py
@@ -1,0 +1,3 @@
+import file1  # disallowed
+
+__all__ = ['file1']

--- a/examples/e02/pkg/special.py
+++ b/examples/e02/pkg/special.py
@@ -1,0 +1,3 @@
+import file1
+
+__all__ = ['file1']


### PR DESCRIPTION
The option is activated by an --allow-all-imports flag.
The named modules are then allowed to import anything.

This supersedes #3 per review comment