### PR TITLE
Allow imports in package

### DIFF
--- a/src/flake8_import_graph/checker.py
+++ b/src/flake8_import_graph/checker.py
@@ -15,6 +15,9 @@ class ImportVisitor(ast.NodeVisitor):
         mod_path = current_module.split('.')
         self.mod_path = mod_path
         self.denied = [v for k, v in denied if is_prefix(k, mod_path)]
+        self.in_package_allowed = [
+            k for k, v in denied if is_prefix(k, mod_path)
+        ]
 
     def visit_Import(self, node):  # noqa: N802
         for name in node.names:
@@ -48,9 +51,12 @@ class ImportVisitor(ast.NodeVisitor):
 
     def not_allowed(self, name):
         dotted = name.split('.')
-        for item in self.denied:
-            if is_prefix(item, dotted):
-                return True
+        return (
+            any(is_prefix(item, dotted) for item in self.denied)
+            and
+            not any(is_prefix(item, dotted) for item in self.in_package_allowed)
+        )
+
 
 class ImportGraphChecker:
     name = "import-graph"


### PR DESCRIPTION
This contains two features, each in its own commit:

- Allow in-package imports which would otherwise be denied
That is, assume a rule like
```
a.b.c=a.b
```
That is, code from `a.b.c` is not supposed to import from `a.b`. This can be very sensible, but if `c` here is a package rather than a module, then this means that code in `a.b.c.d` cannot import from `a.b.c.e`, and this is probably not really the intention. This feature allows imports in such cases.

- Let user designate packages for allowed relative imports
That is, give a list of packages where relative imports are allowed. This makes sense where relative imports are not created automatically by the IDE, and thus allow a user, to a degree, to explicitly override the rules specified otherwise.

Both are presented here for getting feedback -- they are not yet "production ready", missing tests and documentation.